### PR TITLE
Test/maestro 1.2.2 dependencies

### DIFF
--- a/conda/MAESTRO/meta.yaml
+++ b/conda/MAESTRO/meta.yaml
@@ -11,23 +11,23 @@ requirements:
     - xorg-libxrender
     - python >=3.7
     - pip
-    - numpy =1.17.3
-    - scipy =1.4.1
-    - h5py =2.10.0
-    - pytables =3.6.1
+    - numpy >=1.17.3
+    - scipy >=1.4.1
+    - h5py >=2.10.0
+    - pytables >=3.6.1
     - setuptools
-    - snakemake =5.14
-    - rseqc =3.0.0
-    - star =2.7.3a
-    - minimap2 =2.17
-    - samtools =1.9
-    - bedtools =2.29.2
-    - rsem =1.3.2
-    - picard =2.22.0
+    - snakemake >=5.14
+    - rseqc >=3.0.0
+    - star >=2.7.3a
+    - minimap2 >=2.17
+    - samtools >=1.9
+    - bedtools >=2.29.2
+    - rsem >=1.3.2
+    - picard >=2.22.0
     - macs2 >=2.2.6
     - umap-learn
     - pysam # this is needed by sinto
-    - r-base =4.0.2
+    - r-base >=4.0.2
     - r-BiocManager
     - r-devtools
     - r-hdf5r
@@ -77,23 +77,23 @@ requirements:
   run:
     - xorg-libxrender
     - python >=3.7
-    - numpy =1.17.3
-    - scipy =1.4.1
-    - h5py =2.10.0
-    - pytables =3.6.1
+    - numpy >=1.17.3
+    - scipy >=1.4.1
+    - h5py >=2.10.0
+    - pytables >=3.6.1
     - setuptools
-    - snakemake =5.14
-    - rseqc =3.0.0
-    - star =2.7.3a
-    - minimap2 =2.17
-    - samtools =1.9
-    - bedtools =2.29.2
-    - rsem =1.3.2
-    - picard =2.22.0
+    - snakemake >=5.14
+    - rseqc >=3.0.0
+    - star >=2.7.3a
+    - minimap2 >=2.17
+    - samtools >=1.9
+    - bedtools >=2.29.2
+    - rsem >=1.3.2
+    - picard >=2.22.0
     - macs2 >=2.2.6
     - umap-learn 
     - pysam # this is needed by sinto   
-    - r-base =4.0.2
+    - r-base >=4.0.2
     - r-BiocManager
     - r-devtools
     - r-hdf5r

--- a/conda/MAESTRO/meta.yaml
+++ b/conda/MAESTRO/meta.yaml
@@ -9,7 +9,7 @@ source:
 requirements:
   build:
     - xorg-libxrender
-    - python =3.7
+    - python >=3.7
     - pip
     - numpy =1.17.3
     - scipy =1.4.1
@@ -24,7 +24,7 @@ requirements:
     - bedtools =2.29.2
     - rsem =1.3.2
     - picard =2.22.0
-    - macs2 =2.2.6
+    - macs2 >=2.2.6
     - umap-learn
     - pysam # this is needed by sinto
     - r-base =4.0.2
@@ -76,7 +76,7 @@ requirements:
     - bioconductor-TxDb.Mmusculus.UCSC.mm10.knownGene
   run:
     - xorg-libxrender
-    - python =3.7
+    - python >=3.7
     - numpy =1.17.3
     - scipy =1.4.1
     - h5py =2.10.0
@@ -90,7 +90,7 @@ requirements:
     - bedtools =2.29.2
     - rsem =1.3.2
     - picard =2.22.0
-    - macs2 =2.2.6
+    - macs2 >=2.2.6
     - umap-learn 
     - pysam # this is needed by sinto   
     - r-base =4.0.2


### PR DESCRIPTION
Bump the conda dependencies to higher versions by only requiring the minimum versions, including:

- python
- numpy
- scipy
- h5py
- pytables
- snakemake
- rseqc 
- star
- minimap2 
- samtools 
- bedtools 
- rsem 
- picard
- macs2
- r-base

I didn't touch Seurat since I think in their new versions, some functions that we used are obsolete. 