### PR TITLE
Add an option '--binary' to generate binary or original peak count matrix

### DIFF
--- a/MAESTRO/MAESTRO
+++ b/MAESTRO/MAESTRO
@@ -82,7 +82,7 @@ def main():
         merge_10X_h5(directory = args.directory, outprefix = args.outprefix, h5list = args.h5_list, prefixlist = args.cellprefix_list, genome = args.species, datatype = args.datatype)
 
     elif args.subcommand == "scatac-peakcount":
-        peakcount(directory = args.directory, outprefix = args.outprefix, peak = args.peak, fragment = args.fragment, barcode = args.barcode, count_cutoff = args.count_cutoff, cores = args.cores, species = args.species)
+        peakcount(directory = args.directory, outprefix = args.outprefix, peak = args.peak, fragment = args.fragment, barcode = args.barcode, binary = args.binary, count_cutoff = args.count_cutoff, cores = args.cores, species = args.species)
 
     elif args.subcommand == "scatac-genescore":
         genescore(directory = args.directory, outprefix = args.outprefix, fileformat = args.format, peakcount = args.peakcount, feature = args.feature, barcode = args.barcode, genedistance = args.genedistance, species = args.species, model = args.model)

--- a/MAESTRO/scATAC_10x_PeakCount.py
+++ b/MAESTRO/scATAC_10x_PeakCount.py
@@ -3,7 +3,7 @@
 # @E-mail: Dongqingsun96@gmail.com
 # @Date:   2020-02-24 22:26:54
 # @Last Modified by:   Dongqing Sun
-# @Last Modified time: 2020-12-13 16:02:34
+# @Last Modified time: 2020-12-13 20:46:06
 
 import os,sys
 import time
@@ -113,7 +113,7 @@ def filter_fragment_file(barcode_file, frag_file, count_cutoff = 1000):
 
 def bedtools_intersect(barcode, peak_bed):
     """Intersect frag file with peak file to genearate the count output."""
-    os.system("bedtools intersect -wa -a " + peak_bed + " -b " + tmp + "/" + barcode + " -c | awk '{if ($4>0) print $0}' > " + tmp + "/" + barcode + ".bed")
+    os.system("bedtools intersect -wa -a " + peak_bed + " -b " + tmp + "/" + barcode + " -c | awk '{if ($NF>0) print $0}' > " + tmp + "/" + barcode + ".bed")
     return(tmp + "/" + barcode + ".bed")
 
 
@@ -132,7 +132,7 @@ def generate_count_matrix(count_list, peak_list, binary = False):
                 if binary:
                     peak_count[line[0]+'_'+line[1]+'_'+line[2]][0, i] = 1
                 else:
-                    peak_count[line[0]+'_'+line[1]+'_'+line[2]][0, i] = int(line[3])
+                    peak_count[line[0]+'_'+line[1]+'_'+line[2]][0, i] = int(line[-1])
 
     matrix = []
     for k in peak_list:

--- a/MAESTRO/scATAC_microfluidic_PeakCount.py
+++ b/MAESTRO/scATAC_microfluidic_PeakCount.py
@@ -3,7 +3,7 @@
 # @E-mail: Dongqingsun96@gmail.com
 # @Date:   2020-02-28 13:57:12
 # @Last Modified by:   Dongqing Sun
-# @Last Modified time: 2020-12-13 16:39:45
+# @Last Modified time: 2020-12-13 20:48:54
 
 
 import os,sys
@@ -63,7 +63,7 @@ def bedtools_intersect(barcode, bam_dir, peak_bed):
     if not os.path.isfile(bam_dir + "/" + barcode +".sortedByPos.rmdp.unique.bed"):
         error(bam_dir+"/"+barcode+".sortedByPos.rmdp.unique.bed not exist!")
     else:
-        os.system("bedtools intersect -wa -a " + peak_bed + " -b " + bam_dir + "/" + barcode + ".sortedByPos.rmdp.unique.bed -c | awk '{if ($4>0) print $0}' > " + tmp + '/' + barcode + ".bed")
+        os.system("bedtools intersect -wa -a " + peak_bed + " -b " + bam_dir + "/" + barcode + ".sortedByPos.rmdp.unique.bed -c | awk '{if ($NF>0) print $0}' > " + tmp + '/' + barcode + ".bed")
     return(tmp + "/" + barcode + ".bed")
 
 

--- a/MAESTRO/scATAC_microfluidic_PeakCount.py
+++ b/MAESTRO/scATAC_microfluidic_PeakCount.py
@@ -3,7 +3,7 @@
 # @E-mail: Dongqingsun96@gmail.com
 # @Date:   2020-02-28 13:57:12
 # @Last Modified by:   Dongqing Sun
-# @Last Modified time: 2020-03-03 20:57:34
+# @Last Modified time: 2020-12-13 16:39:45
 
 
 import os,sys
@@ -16,7 +16,7 @@ from functools import partial
 
 from MAESTRO.scATAC_utility import *
 from MAESTRO.scATAC_H5Process import *
-from MAESTRO.scATAC_10x_PeakCount import merge_binary_file, generate_binary_matrix
+from MAESTRO.scATAC_10x_PeakCount import merge_count_file, generate_count_matrix
 
 tmp = randomString()
 
@@ -39,6 +39,10 @@ def CommandLineParser():
         "Each line of the file represents a valid barcode. "
         "If not set, the barcodes with enough read count (> --count-cutoff) "
         "in the fragment file will be used to generate peak-cell binary count matrix.")
+    group_input.add_argument("--binary", dest = "binary", action = "store_true",
+        help = "Whether or not to generate binary peak count matrix. If set, "
+        "MAESTRO will binarize the peak-cell count matrix. "
+        "If not (by default), MAESTRO will generate the original peak-count matrix. ")
     group_input.add_argument("--species", dest = "species", default = "GRCh38", 
         choices = ["GRCh38", "GRCm38"], type = str, 
         help = "Species (GRCh38 for human and GRCm38 for mouse). DEFAULT: GRCh38.")
@@ -59,7 +63,7 @@ def bedtools_intersect(barcode, bam_dir, peak_bed):
     if not os.path.isfile(bam_dir + "/" + barcode +".sortedByPos.rmdp.unique.bed"):
         error(bam_dir+"/"+barcode+".sortedByPos.rmdp.unique.bed not exist!")
     else:
-        os.system("bedtools intersect -wa -a " + peak_bed + " -b " + bam_dir + "/" + barcode + ".sortedByPos.rmdp.unique.bed -u > " + tmp + '/' + barcode + ".bed")
+        os.system("bedtools intersect -wa -a " + peak_bed + " -b " + bam_dir + "/" + barcode + ".sortedByPos.rmdp.unique.bed -c | awk '{if ($4>0) print $0}' > " + tmp + '/' + barcode + ".bed")
     return(tmp + "/" + barcode + ".bed")
 
 
@@ -74,6 +78,7 @@ def main():
     bam_dir = myparser.bam_dir
     cores = int(myparser.cores)
     genome = myparser.species
+    binary = myparser.binary
 
     try:
         os.makedirs(directory)
@@ -97,7 +102,7 @@ def main():
     pool.join()
 
     count_list = result.get()
-    merge_binary_file(peak_file, count_list, count_file, cores, genome)
+    merge_count_file(peak_file, count_list, count_file, cores, binary, genome)
     shutil.rmtree(tmp)
 
 if __name__ == "__main__":

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,7 +14,7 @@ TEST1_OUTPUT_DIR=${TEST_PREFIX}_peakcount_dir
 TEST1_OUTPUT_FILE=${TEST1_OUTPUT_DIR}/${TEST_PREFIX}_peak_count.h5
 TEST1_STD_OUTPUT=${STD_OUTPUT_DIR}/${TEST_PREFIX}_peak_count.h5
 
-MAESTRO scatac-peakcount --peak $TEST_PEAK_GZ --fragment $TEST_FRAG_GZ --barcode $TEST_BC_GZ --species GRCh38 --cores 1 --outprefix $TEST_PREFIX -d ${TEST1_OUTPUT_DIR}
+MAESTRO scatac-peakcount --peak $TEST_PEAK_GZ --fragment $TEST_FRAG_GZ --barcode $TEST_BC_GZ --species GRCh38 --cores 1 --outprefix $TEST_PREFIX -d ${TEST1_OUTPUT_DIR} --binary
 
 echo "1. Check if the output is the same as the standard output"
 # Check if the output file is the same as standard output


### PR DESCRIPTION
Add an option `--binary` to generate binary or original peak count matrix, and set 'original' by as default.