### PR TITLE
Fix input path in Snakefile.

### DIFF
--- a/MAESTRO/Snakemake/scATAC/Snakefile
+++ b/MAESTRO/Snakemake/scATAC/Snakefile
@@ -1158,8 +1158,7 @@ rule scatac_qcfilter:
 
 rule scatac_genescore:
     input:
-        filtercount = "Result/QC/%s_filtered_
-        unt.h5" %(config["outprefix"]),
+        filtercount = "Result/QC/%s_filtered_peak_count.h5" %(config["outprefix"]),
         genebed = "%s/annotations/%s_ensembl.bed" %(SCRIPT_PATH, config["species"]),
     output:
         genescore = "Result/Analysis/%s_gene_score.h5" %(config["outprefix"])


### PR DESCRIPTION
The scATAC Snakefile from v1.3.1 has a broken input path specification that cases the pipeline to fail.

This should fix #101 