### PR TITLE
Fix bug of negative count value generated by scatac-peakcount

### DIFF
--- a/MAESTRO/scATAC_10x_PeakCount.py
+++ b/MAESTRO/scATAC_10x_PeakCount.py
@@ -3,7 +3,7 @@
 # @E-mail: Dongqingsun96@gmail.com
 # @Date:   2020-02-24 22:26:54
 # @Last Modified by:   Dongqing Sun
-# @Last Modified time: 2020-12-13 20:46:06
+# @Last Modified time: 2021-03-15 22:30:19
 
 import os,sys
 import time
@@ -119,7 +119,7 @@ def generate_count_matrix(count_list, peak_list, binary = False):
 
     peak_count = {}
     for peak in peak_list:
-        peak_count[peak] = sp_sparse.dok_matrix((1, len(count_list)), dtype=np.int8)
+        peak_count[peak] = sp_sparse.dok_matrix((1, len(count_list)), dtype=np.int32)
     
     barcodes = []
     for i in range(0,len(count_list)):

--- a/MAESTRO/scATAC_H5Process.py
+++ b/MAESTRO/scATAC_H5Process.py
@@ -3,7 +3,7 @@
 # @E-mail: Dongqingsun96@gmail.com
 # @Date:   2020-02-23 19:44:05
 # @Last Modified by:   Dongqing Sun
-# @Last Modified time: 2020-11-02 22:31:18
+# @Last Modified time: 2021-03-15 22:31:14
 
 
 import os
@@ -196,7 +196,7 @@ def write_10X_h5(filename, matrix, features, barcodes, genome = 'GRCh38', dataty
     """Write 10X HDF5 files, support both gene expression and peaks."""
     f = h5py.File(filename, 'w')
     if datatype == 'Peak':
-       M = sp_sparse.csc_matrix(matrix, dtype=numpy.int8)
+       M = sp_sparse.csc_matrix(matrix, dtype=numpy.int32)
     else:
        M = sp_sparse.csc_matrix(matrix, dtype=numpy.float32)
     B = numpy.array(barcodes, dtype='|S200')


### PR DESCRIPTION
Change type of `int8` to `int32` to avoid negative count values.