### PR TITLE
Fix/long rna barcode reads

### DIFF
--- a/MAESTRO/MAESTRO_PipeInit.py
+++ b/MAESTRO/MAESTRO_PipeInit.py
@@ -252,6 +252,11 @@ def scrna_parser(subparsers):
     group_barcode.add_argument("--umi-length", dest = "umi_length", type = int, default = 10,
         help = "The length of UMI. For 10x-genomics, the length of V2 chemistry is 10. "
         "For 10X V3 chemistry, the length is 12. DEFAULT: 10. ")
+    group_barcode.add_argument("--trimR1", dest = "trimR1", action = "store_true",
+        help = "Whether or not to run the R1 file. "
+        "If set, the pipeline will include the trim off anything after the R1 reads past barcode information. "
+        "Only necessary if reads were sequenced past these barcodes, by default not set.")
+
 
     # Regulator identification
     group_regulator = workflow.add_argument_group("Regulator identification arguments")
@@ -595,6 +600,7 @@ def scrna_config(args):
             barcodelength = args.barcode_length,
             umistart = args.umi_start,
             umilength = args.umi_length,
+            trimr1 = args.trimR1,
             barcode = args.fastq_barcode,
             transcript = args.fastq_transcript))
 

--- a/MAESTRO/Snakemake/scRNA/Snakefile
+++ b/MAESTRO/Snakemake/scRNA/Snakefile
@@ -17,27 +17,46 @@ rule all:
 
 
 if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
+    if config["barcode"]["trimR1"]:
+        rule trimR1:
+            input:
+                origbarcode = getfastq_10x(config["fastqdir"], config["fastqprefix"])["barcode"].split(sep=",")
+            output:
+                tempbarcode = temp(expand("{fastq}.tmp.fastq.gz", fastq=getfastq_10x(config["fastqdir"], config["fastqprefix"])["barcode"].split(sep=",")))
+            params:
+                outdir = "Result/STAR/" + config["outprefix"],
+                barcodelength = config["barcode"]["barcodelength"],
+                umilength = config["barcode"]["umilength"]
+            shell:
+                "for var in {input.origbarcode}; "
+                "do "
+                    "gunzip -c $var | "
+                    "awk -v barlen=$(({params.barcodelength}+{params.umilength})) "
+                    "'{{if(!($1 ~/^@/) && !($0==\"+\")){{print substr($0,1,barlen)}} else {{print}}}}' | "
+                    "gzip -c > ${{var}}.tmp.fastq.gz; "
+                "done"
+    
     if config["platform"] == "10x-genomics":
         rule scrna_map:
             input:
                 mapindex = config["genome"]["mapindex"],
                 whitelist = config["barcode"]["whitelist"],
                 fastqs = config["fastqdir"],
+                barcode = expand("{fastq}.tmp.fastq.gz", fastq=getfastq_10x(config["fastqdir"], config["fastqprefix"])["barcode"].split(sep=",")) if config["barcode"]["trimR1"] else (getfastq_10x(config["fastqdir"], config["fastqprefix"])["barcode"]).split(",")
             output:
                 bam = "Result/STAR/%sAligned.sortedByCoord.out.bam" %(config["outprefix"]),
                 bai = "Result/STAR/%sAligned.sortedByCoord.out.bam.bai" %(config["outprefix"]),
                 rawmtx = "Result/STAR/%sSolo.out/Gene/raw/matrix.mtx" %(config["outprefix"]),
                 feature = "Result/STAR/%sSolo.out/Gene/raw/features.tsv" %(config["outprefix"]),
-                barcode = "Result/STAR/%sSolo.out/Gene/raw/barcodes.tsv" %(config["outprefix"]),
+                barcode = "Result/STAR/%sSolo.out/Gene/raw/barcodes.tsv" %(config["outprefix"])
             params:
                 outdir = "Result/STAR/" + config["outprefix"],
-                transcript = getfastq_10x(config["fastqdir"], config["fastqprefix"])["transcript"],
-                barcode = getfastq_10x(config["fastqdir"], config["fastqprefix"])["barcode"],
                 decompress = getfastq_10x(config["fastqdir"], config["fastqprefix"])["decompress"],
+                transcript = getfastq_10x(config["fastqdir"], config["fastqprefix"])["transcript"],
                 barcodestart = config["barcode"]["barcodestart"],
                 barcodelength = config["barcode"]["barcodelength"],
                 umistart = config["barcode"]["umistart"],
-                umilength = config["barcode"]["umilength"],
+                umilength = config["barcode"]["umilength"]
             log:
                 "Result/Log/%s_STAR.log" %(config["outprefix"])
             benchmark:
@@ -45,19 +64,16 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
             threads:
                 config["cores"]
             shell:
-                "gunzip -c {params.barcode} | "
-                "awk -v barlen=$(({params.barcodelength}+{params.umilength})) '{{if(!($1 ~/^@/) && !($0=="+")){{print substr($0,1,barlen)}} else {{print}}}}' | "
-                "gzip -c > {params.outdir}Temp.R1.tmp.fastq.gz;"
                 "STAR --runMode alignReads --genomeDir {input.mapindex} --runThreadN {threads} "
                 "--outFileNamePrefix {params.outdir} --outSAMtype BAM SortedByCoordinate "
                 "--soloType CB_UMI_Simple --soloCBwhitelist {input.whitelist} "
                 "--soloCBstart {params.barcodestart} --soloCBlen {params.barcodelength} "
                 "--soloUMIstart {params.umistart} --soloUMIlen {params.umilength} "
                 "--soloCBmatchWLtype 1MM_multi_pseudocounts --soloUMIfiltering MultiGeneUMI "
-                "--readFilesIn {params.transcript} {params.barcode} --readFilesCommand {params.decompress} "
-                "> {log};"
-                "samtools index -b -@ {threads} {output.bam};"
-                "rm {params.outdir}Temp.R1.tmp.fastq.gz"
+                "--readFilesIn {params.transcript} $(echo {input.barcode} | tr ' ' ',') "
+                "--readFilesCommand {params.decompress} "
+                "> {log}; "
+                "samtools index -b -@ {threads} {output.bam}"
     else:
         rule scrna_map:
             input:
@@ -86,9 +102,6 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
             benchmark:
                 "Result/Benchmark/%s_STAR.benchmark" %(config["outprefix"])
             shell:
-                "gunzip -c {params.barcode} | "
-                "awk -v barlen=$(({params.barcodelength}+{params.umilength})) '{{if(!($1 ~/^@/) && !($0=="+")){{print substr($0,1,barlen)}} else {{print}}}}' | "
-                "gzip -c > {params.outdir}Temp.R1.tmp.fastq.gz;"
                 "STAR --runMode alignReads --genomeDir {input.mapindex} --runThreadN {threads} "
                 "--outFileNamePrefix {params.outdir} --outSAMtype BAM SortedByCoordinate "
                 "--soloType CB_UMI_Simple --soloCBwhitelist {input.whitelist} "
@@ -98,7 +111,6 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
                 "--readFilesIn {params.transcript} {params.barcode} --readFilesCommand {params.decompress} "
                 "> {log};"
                 "samtools index -b -@ {threads} {output.bam};"
-                "rm {params.outdir}Temp.R1.tmp.fastq.gz"
 
     rule scrna_qc:
         input:

--- a/MAESTRO/Snakemake/scRNA/Snakefile
+++ b/MAESTRO/Snakemake/scRNA/Snakefile
@@ -47,7 +47,7 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
             shell:
                 "gunzip -c {params.barcode} | "
                 "awk -v barlen=$(({params.barcodelength}+{params.umilength})) '{{if(!($1 ~/^@/) && !($0=="+")){{print substr($0,1,barlen)}} else {{print}}}}' | "
-                "gzip -c > {params.outprefix}.R1.tmp.fastq.gz;"
+                "gzip -c > {params.outdir}Temp.R1.tmp.fastq.gz;"
                 "STAR --runMode alignReads --genomeDir {input.mapindex} --runThreadN {threads} "
                 "--outFileNamePrefix {params.outdir} --outSAMtype BAM SortedByCoordinate "
                 "--soloType CB_UMI_Simple --soloCBwhitelist {input.whitelist} "
@@ -57,7 +57,7 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
                 "--readFilesIn {params.transcript} {params.barcode} --readFilesCommand {params.decompress} "
                 "> {log};"
                 "samtools index -b -@ {threads} {output.bam};"
-                "rm {params.outprefix}.R1.tmp.fastq.gz"
+                "rm {params.outdir}Temp.R1.tmp.fastq.gz"
     else:
         rule scrna_map:
             input:
@@ -86,6 +86,9 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
             benchmark:
                 "Result/Benchmark/%s_STAR.benchmark" %(config["outprefix"])
             shell:
+                "gunzip -c {params.barcode} | "
+                "awk -v barlen=$(({params.barcodelength}+{params.umilength})) '{{if(!($1 ~/^@/) && !($0=="+")){{print substr($0,1,barlen)}} else {{print}}}}' | "
+                "gzip -c > {params.outdir}Temp.R1.tmp.fastq.gz;"
                 "STAR --runMode alignReads --genomeDir {input.mapindex} --runThreadN {threads} "
                 "--outFileNamePrefix {params.outdir} --outSAMtype BAM SortedByCoordinate "
                 "--soloType CB_UMI_Simple --soloCBwhitelist {input.whitelist} "
@@ -94,7 +97,8 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
                 "--soloCBmatchWLtype 1MM_multi_pseudocounts --soloUMIfiltering MultiGeneUMI "
                 "--readFilesIn {params.transcript} {params.barcode} --readFilesCommand {params.decompress} "
                 "> {log};"
-                "samtools index -b -@ {threads} {output.bam}"
+                "samtools index -b -@ {threads} {output.bam};"
+                "rm {params.outdir}Temp.R1.tmp.fastq.gz"
 
     rule scrna_qc:
         input:

--- a/MAESTRO/Snakemake/scRNA/Snakefile
+++ b/MAESTRO/Snakemake/scRNA/Snakefile
@@ -45,6 +45,9 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
             threads:
                 config["cores"]
             shell:
+                "gunzip -c {params.barcode} | "
+                "awk -v barlen=$(({params.barcodelength}+{params.umilength})) '{{if(!($1 ~/^@/) && !($0=="+")){{print substr($0,1,barlen)}} else {{print}}}}' | "
+                "gzip -c > {params.outprefix}.R1.tmp.fastq.gz;"
                 "STAR --runMode alignReads --genomeDir {input.mapindex} --runThreadN {threads} "
                 "--outFileNamePrefix {params.outdir} --outSAMtype BAM SortedByCoordinate "
                 "--soloType CB_UMI_Simple --soloCBwhitelist {input.whitelist} "
@@ -53,7 +56,8 @@ if config["platform"] == "10x-genomics" or config["platform"] == "Dropseq":
                 "--soloCBmatchWLtype 1MM_multi_pseudocounts --soloUMIfiltering MultiGeneUMI "
                 "--readFilesIn {params.transcript} {params.barcode} --readFilesCommand {params.decompress} "
                 "> {log};"
-                "samtools index -b -@ {threads} {output.bam}"
+                "samtools index -b -@ {threads} {output.bam};"
+                "rm {params.outprefix}.R1.tmp.fastq.gz"
     else:
         rule scrna_map:
             input:

--- a/MAESTRO/Snakemake/scRNA/config_template.yaml
+++ b/MAESTRO/Snakemake/scRNA/config_template.yaml
@@ -73,6 +73,9 @@ barcode:
   # The length of UMI. For 10x-genomics, the length of V2 chemistry is 10.
   # For 10X V3 chemistry, the length is 12. DEFAULT: 10.
   umilength: {{ umilength }}
+  # Whether to trim the R1 file, to make it compatible with STARsolo if it extends beyond the 
+  # barcodes
+  trimR1: {{ trimr1 }}
 
 
 # Specify the barcode fastq file and transcript fastq file (only for platform of "Dropseq")


### PR DESCRIPTION
This is a fix for when the barcode scRNA fastq file reads run longer than the barcode and umi, which raises an error in STARSolo. This fix just trims down these reads to the length of barcode + umi. 