### PR TITLE
update the reference T2TCHM13 of scatac-genescore

### DIFF
--- a/MAESTRO/scATAC_Genescore.py
+++ b/MAESTRO/scATAC_Genescore.py
@@ -51,7 +51,7 @@ def genescore_parser(subparsers):
         "to 10kb (enhancer-based regulation). DEFAULT: 10000.")
     group_input.add_argument("--species", dest = "species", default = "GRCh38", 
         choices = ["GRCh38", "GRCm38", "T2TCHM13"], type = str, 
-        help = "Species (GRCh38 for human and GRCm38 for mouse). DEFAULT: GRCh38.")
+        help = "Species (GRCh38/T2TCHM13 for human and GRCm38 for mouse). DEFAULT: GRCh38.")
     group_input.add_argument("--model", dest = "model", default = "Enhanced", 
         choices = ["Simple", "Enhanced"], type = str, 
         help = "The RP model to use to calaculate gene score. "

--- a/MAESTRO/scATAC_Genescore.py
+++ b/MAESTRO/scATAC_Genescore.py
@@ -50,7 +50,7 @@ def genescore_parser(subparsers):
         help = "Gene score decay distance, could be optional from 1kb (promoter-based regulation) "
         "to 10kb (enhancer-based regulation). DEFAULT: 10000.")
     group_input.add_argument("--species", dest = "species", default = "GRCh38", 
-        choices = ["GRCh38", "GRCm38"], type = str, 
+        choices = ["GRCh38", "GRCm38", "T2TCHM13"], type = str, 
         help = "Species (GRCh38 for human and GRCm38 for mouse). DEFAULT: GRCh38.")
     group_input.add_argument("--model", dest = "model", default = "Enhanced", 
         choices = ["Simple", "Enhanced"], type = str, 


### PR DESCRIPTION
add file 'annotations/T2TCHM13_refgenes.txt'
add argument 'T2TCHM13' for scatac-genescore in file 'scATAC_Genescore.py'

Since I used the T2TCHM13 reference genome for the scATAC-seq comparison, after comparing the difference between GRCh38 and T2TCHM13, I found that there is a difference in the chromosomal location of the same gene, and if I use GRCh38 to calculate gene activity I may not end up with the expected result, so I extracted the T2TCHM13.gtf file The file 'T2TCHM13_refgenes.txt' was written in the format of 'GRCh38_refgenes.txt', which is now shared with the modified commands.